### PR TITLE
Added InUseThreads to WorkItemGroup

### DIFF
--- a/SmartThreadPool/Interfaces.cs
+++ b/SmartThreadPool/Interfaces.cs
@@ -85,6 +85,11 @@ namespace Amib.Threading
         int WaitingCallbacks { get; }
 
         /// <summary>
+        /// Get the number of currently executing work items
+        /// </summary>
+        int InUseThreads { get; }
+
+        /// <summary>
         /// Get an array with all the state objects of the currently running items.
         /// The array represents a snap shot and impact performance.
         /// </summary>

--- a/SmartThreadPool/SmartThreadPool.cs
+++ b/SmartThreadPool/SmartThreadPool.cs
@@ -1395,18 +1395,6 @@ namespace Amib.Threading
 			} 
 		}
 
-		/// <summary>
-		/// Get the number of busy (not idle) threads in the thread pool.
-		/// </summary>
-		public int InUseThreads 
-		{ 
-			get 
-			{ 
-				ValidateNotDisposed();
-				return _inUseWorkerThreads; 
-			} 
-		}
-
         /// <summary>
         /// Returns true if the current running work item has been cancelled.
         /// Must be used within the work item's callback method.
@@ -1507,6 +1495,18 @@ namespace Amib.Threading
 	        get { return MaxThreads; }
 	        set { MaxThreads = value; }
 	    }
+
+        /// <summary>
+        /// Get the number of busy (not idle) threads in the thread pool.
+        /// </summary>
+        public override int InUseThreads
+        {
+            get
+            {
+                ValidateNotDisposed();
+                return _inUseWorkerThreads;
+            }
+        }
 
 	    /// <summary>
 	    /// Get the number of work items in the queue.

--- a/SmartThreadPool/WorkItemsGroup.cs
+++ b/SmartThreadPool/WorkItemsGroup.cs
@@ -126,6 +126,14 @@ namespace Amib.Threading.Internal
             }
         }
 
+        public override int InUseThreads
+        {
+            get
+            {
+                return _workItemsExecutingInStp;
+            }
+        }
+
         public override int WaitingCallbacks
         {
             get { return _workItemsQueue.Count; }

--- a/SmartThreadPool/WorkItemsGroupBase.cs
+++ b/SmartThreadPool/WorkItemsGroupBase.cs
@@ -39,6 +39,8 @@ namespace Amib.Threading.Internal
 
         public abstract int Concurrency { get; set; }
         public abstract int WaitingCallbacks { get; }
+        public abstract int InUseThreads { get; }
+
         public abstract object[] GetStates();
         public abstract WIGStartInfo WIGStartInfo { get; }
         public abstract void Start();


### PR DESCRIPTION
I needed the current number of threads running in a WorkItemGroup, so I added it to the interface and the WorkItemGroup.