### PR TITLE
Fix to make STP work on .NET 2.0 sp0

### DIFF
--- a/SmartThreadPool/Properties/AssemblyInfo.cs
+++ b/SmartThreadPool/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("c764a3de-c4f8-434d-85b5-a09830d1e44f")]
-[assembly: AssemblyVersion("2.2.3.0")]
+[assembly: AssemblyVersion("2.2.3.1")]
 
 #if (_PUBLISH)
 [assembly: InternalsVisibleTo("STPTests,PublicKey=00240000048000009400000006020000002400005253413100040000010001004fe3d39add741ba7c8d52cd1eb0d94c7d79060ad956cbaff0e51c1dce94db10356b261778bc1ac3114b3218434da6fcd8416dd5507653809598f7d2afc422099ce4f6b7b0477f18e6c57c727ef2a7ab6ee56e6b4589fe44cb0e25f2875a3c65ab0383ee33c4dd93023f7ce1218bebc8b7a9a1dac878938f5c4f45ea74b6bd8ad")]

--- a/SmartThreadPool/STPEventWaitHandle.cs
+++ b/SmartThreadPool/STPEventWaitHandle.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace Amib.Threading.Internal
 {
-#if _WINDOWS ||  WINDOWS_PHONE
+#if _SILVERLIGHT || WINDOWS_PHONE
     internal static class STPEventWaitHandle
     {
         public const int WaitTimeout = Timeout.Infinite;


### PR DESCRIPTION
The referenced commit makes STP compatible with unpatched .NET 2.0, yet doesn't cause any problems on patched or later versions of .NET.
