### PR TITLE
Add MaxQueueLength property to support bounded queues

### DIFF
--- a/STPTests/STPTests.csproj
+++ b/STPTests/STPTests.csproj
@@ -131,6 +131,7 @@
     <Compile Include="AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="TestMaxQueueLength.cs" />
     <Compile Include="TestThreadIsBackground.cs" />
     <Compile Include="TestThreadApartmentState.cs" />
     <Compile Include="TestParallelMethods.cs" />

--- a/STPTests/TestMaxQueueLength.cs
+++ b/STPTests/TestMaxQueueLength.cs
@@ -40,9 +40,6 @@ namespace STPTests
             try
             {
                 pool.QueueWorkItem(SleepForOneSecond); // Taken by waiter immediately. Not queued.
-
-                Thread.Sleep(100); // A pause to get around any locks and make sure the waiter picked up the task.
-
                 pool.QueueWorkItem(SleepForOneSecond); // No waiters available, pool at max threads. Queued.
             }
             catch (QueueRejectedException e)
@@ -82,8 +79,6 @@ namespace STPTests
                 pool.QueueWorkItem(SleepForOneSecond); // New thread created, takes work item. Not queued.
                 pool.QueueWorkItem(SleepForOneSecond); // New thread created, takes work item. Not queued.
                 pool.QueueWorkItem(SleepForOneSecond); // New thread created, takes work item. Not queued.
-
-                Thread.Sleep(100); // A pause to get around any locks and make sure the waiters picked everything up.
 
                 pool.QueueWorkItem(SleepForOneSecond); // No waiters available. Queued.
                 pool.QueueWorkItem(SleepForOneSecond); // No waiters available. Queued.

--- a/STPTests/TestMaxQueueLength.cs
+++ b/STPTests/TestMaxQueueLength.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Threading;
+using Amib.Threading;
+using NUnit.Framework;
+
+namespace STPTests
+{
+    [TestFixture]
+    [Category("TestMaxQueueLength")]
+    public class TestMaxQueueLength
+    {
+        [Test]
+        public void QueueWorkItem_WhenMaxIsNull_Queues()
+        {
+            var info = new STPStartInfo
+            {
+                MaxQueueLength = null,
+            };
+            var pool = new SmartThreadPool(info);
+            pool.Start();
+            var workItem = pool.QueueWorkItem<object>(ReturnNull);
+
+            // If rejected, an exception would have been thrown instead.
+            Assert.IsTrue(workItem.GetResult() == null);
+        }
+
+        [Test]
+        [ExpectedException(typeof(QueueRejectedException))]
+        public void QueueWorkItem_WhenMaxIsSet_ThrowsExceptionWhenHit()
+        {
+            var info = new STPStartInfo
+            {
+                MaxQueueLength = 1,
+                MinWorkerThreads = 1,
+                MaxWorkerThreads = 1,
+            };
+            var pool = new SmartThreadPool(info);
+            pool.Start();
+
+            try
+            {
+                pool.QueueWorkItem(SleepForOneSecond); // Taken by waiter immediately. Not queued.
+
+                Thread.Sleep(100); // A pause to get around any locks and make sure the waiter picked up the task.
+
+                pool.QueueWorkItem(SleepForOneSecond); // No waiters available, pool at max threads. Queued.
+            }
+            catch (QueueRejectedException e)
+            {
+                throw new Exception("Caught QueueRejectedException too early: ", e);
+            }
+
+            // No waiters available, queue is at max (1). Throws.
+            pool.QueueWorkItem(SleepForOneSecond);
+        }
+
+        [Test, RequiresThread]
+        [ExpectedException(typeof (QueueRejectedException))]
+        public void QueueWorkItem_WhenBiggerMaxIsSet_ThrowsExceptionWhenHit()
+        {
+            var info = new STPStartInfo
+            {
+                MaxQueueLength = 5,
+                MinWorkerThreads = 5,
+                MaxWorkerThreads = 10,
+            };
+            var pool = new SmartThreadPool(info);
+            pool.Start();
+
+            try
+            {
+                // Pool starts with 5 available waiters.
+
+                pool.QueueWorkItem(SleepForOneSecond); // Taken by waiter immediately. Not queued.
+                pool.QueueWorkItem(SleepForOneSecond); // Taken by waiter immediately. Not queued.
+                pool.QueueWorkItem(SleepForOneSecond); // Taken by waiter immediately. Not queued.
+                pool.QueueWorkItem(SleepForOneSecond); // Taken by waiter immediately. Not queued.
+                pool.QueueWorkItem(SleepForOneSecond); // Taken by waiter immediately. Not queued.
+
+                pool.QueueWorkItem(SleepForOneSecond); // New thread created, takes work item. Not queued.
+                pool.QueueWorkItem(SleepForOneSecond); // New thread created, takes work item. Not queued.
+                pool.QueueWorkItem(SleepForOneSecond); // New thread created, takes work item. Not queued.
+                pool.QueueWorkItem(SleepForOneSecond); // New thread created, takes work item. Not queued.
+                pool.QueueWorkItem(SleepForOneSecond); // New thread created, takes work item. Not queued.
+
+                Thread.Sleep(100); // A pause to get around any locks and make sure the waiters picked everything up.
+
+                pool.QueueWorkItem(SleepForOneSecond); // No waiters available. Queued.
+                pool.QueueWorkItem(SleepForOneSecond); // No waiters available. Queued.
+                pool.QueueWorkItem(SleepForOneSecond); // No waiters available. Queued.
+                pool.QueueWorkItem(SleepForOneSecond); // No waiters available. Queued.
+                pool.QueueWorkItem(SleepForOneSecond); // No waiters available. Queued.
+            }
+            catch (QueueRejectedException e)
+            {
+                throw new Exception("Caught QueueRejectedException too early: ", e);
+            }
+
+            // All threads are busy, and queue is at its max. Throws.
+            pool.QueueWorkItem(SleepForOneSecond);
+        }
+
+        private object ReturnNull()
+        {
+            return null;
+        }
+
+        private void SleepForOneSecond()
+        {
+            Thread.Sleep(1000);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void StpStartInfo_WithNegativeMaxQueueLength_FailsValidation()
+        {
+            var info = new STPStartInfo
+            {
+                MaxQueueLength = -1,
+            };
+            new SmartThreadPool(info);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void StpStartInfo_WithZeroMaxQueueLength_FailsValidation()
+        {
+            var info = new STPStartInfo
+            {
+                MaxQueueLength = 0,
+            };
+            new SmartThreadPool(info);
+        }
+    }
+}

--- a/SmartThreadPool/QueueRejectedException.cs
+++ b/SmartThreadPool/QueueRejectedException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Amib.Threading
+{
+    public class QueueRejectedException : Exception
+    {
+        public QueueRejectedException(string message) : base(message) {}
+    }
+}

--- a/SmartThreadPool/STPStartInfo.cs
+++ b/SmartThreadPool/STPStartInfo.cs
@@ -19,6 +19,7 @@ namespace Amib.Threading
         private bool _enableLocalPerformanceCounters;
         private string _threadPoolName = SmartThreadPool.DefaultThreadPoolName;
         private int? _maxStackSize = SmartThreadPool.DefaultMaxStackSize;
+	    private int? _maxQueueLength = SmartThreadPool.DefaultMaxQueueLength;
 
         public STPStartInfo()
         {
@@ -44,6 +45,7 @@ namespace Amib.Threading
             _enableLocalPerformanceCounters = stpStartInfo._enableLocalPerformanceCounters;
             _threadPoolName = stpStartInfo._threadPoolName;
             _areThreadsBackground = stpStartInfo.AreThreadsBackground;
+	        _maxQueueLength = stpStartInfo.MaxQueueLength;
 #if !(_SILVERLIGHT) && !(WINDOWS_PHONE)
             _apartmentState = stpStartInfo._apartmentState;
 #endif
@@ -160,6 +162,26 @@ namespace Amib.Threading
  	            _areThreadsBackground = value;
  	        }
  	    }
+
+        /// <summary>
+        /// The maximum number of items allowed in the queue. Items attempting to be queued
+        /// when the queue is at its maximum will throw a QueueRejectedException.
+        /// 
+        /// Value must be > 0. A <code>null</code> value will leave the queue unbounded (i.e.
+        /// bounded only by available resources).
+        /// 
+        /// Ignored when <code>Enqueue()</code>ing on a Thread Pool from within a
+        /// <code>WorkItemsGroup</code>.
+        /// </summary>
+	    public virtual int? MaxQueueLength
+	    {
+	        get { return _maxQueueLength; }
+	        set
+	        {
+	            ThrowIfReadOnly();
+                _maxQueueLength = value;
+	        }
+	    }
 
 	    /// <summary>
         /// Get a readonly version of this STPStartInfo.

--- a/SmartThreadPool/SmartThreadPool.cs
+++ b/SmartThreadPool/SmartThreadPool.cs
@@ -1344,7 +1344,11 @@ namespace Amib.Threading
 
 	    private void ValidateQueueIsWithinLimits()
 	    {
-	        if (_stpStartInfo.MaxQueueLength == null)
+            // Keep a local copy; if a client changes the length while this is executing,
+            // we'll want to use the same value throughout.
+	        var maxQueueLength = _stpStartInfo.MaxQueueLength;
+
+	        if (maxQueueLength == null)
 	        {
 	            return;
 	        }
@@ -1353,10 +1357,9 @@ namespace Amib.Threading
             // fact that the pool is going to scale up its threads if it's not yet at its
             // maximum and there are queued items. This means that the queue length limit
             // may be briefly exceeded while the pool is scaling up.
-
-            if (_currentWorkItemsCount >= _stpStartInfo.MaxQueueLength + MaxThreads)
+            if (_currentWorkItemsCount >= maxQueueLength + MaxThreads)
 	        {
-	            throw new QueueRejectedException("Queue is at its maximum (" + _stpStartInfo.MaxQueueLength + ")");
+	            throw new QueueRejectedException("Queue is at its maximum (" + maxQueueLength + ")");
 	        }
 	    }
 
@@ -1410,6 +1413,21 @@ namespace Amib.Threading
                 StartOptimalNumberOfThreads();
             } 
 		}
+
+	    public int? MaxQueueLength
+	    {
+	        get
+	        {
+	            ValidateNotDisposed();
+	            return _stpStartInfo.MaxQueueLength;
+	        }
+
+	        set
+	        {
+	            _stpStartInfo.MaxQueueLength = value;
+	        }
+	    }
+
 		/// <summary>
 		/// Get the number of threads in the thread pool.
 		/// Should be between the lower and the upper limits.

--- a/SmartThreadPool/SmartThreadPool.cs
+++ b/SmartThreadPool/SmartThreadPool.cs
@@ -530,7 +530,7 @@ namespace Amib.Threading
 					"MaxWorkerThreads must be greater or equal to MinWorkerThreads");
 			}
 
-		    if (_stpStartInfo.MaxQueueLength <= 0)
+		    if (_stpStartInfo.MaxQueueLength < 0)
 		    {
                 throw new ArgumentOutOfRangeException(
                     "MaxQueueLength",

--- a/SmartThreadPool/SmartThreadPool.cs
+++ b/SmartThreadPool/SmartThreadPool.cs
@@ -250,7 +250,7 @@ namespace Amib.Threading
 		/// Total number of work items that are stored in the work items queue 
 		/// plus the work items that the threads in the pool are working on.
 		/// </summary>
-		private int _currentWorkItemsCount;
+		private volatile int _currentWorkItemsCount;
 
 		/// <summary>
 		/// Signaled when the thread pool is idle, i.e. no thread is busy
@@ -1452,6 +1452,19 @@ namespace Amib.Threading
 				return _inUseWorkerThreads; 
 			} 
 		}
+
+        /// <summary>
+        /// Get the number of work items that haven't finished execution (i.e.
+        /// items being worked on by threads + items in the queue).
+        /// </summary>
+	    public int CurrentWorkItemsCount
+	    {
+	        get
+	        {
+	            ValidateNotDisposed();
+	            return _currentWorkItemsCount;
+	        }
+	    }
 
         /// <summary>
         /// Returns true if the current running work item has been cancelled.

--- a/SmartThreadPool/SmartThreadPool.cs
+++ b/SmartThreadPool/SmartThreadPool.cs
@@ -1354,8 +1354,7 @@ namespace Amib.Threading
             // maximum and there are queued items. This means that the queue length limit
             // may be briefly exceeded while the pool is scaling up.
 
-	        var availableThreads = _stpStartInfo.MaxWorkerThreads - _inUseWorkerThreads;
-	        if (_workItemsQueue.Count >= _stpStartInfo.MaxQueueLength + availableThreads)
+            if (_currentWorkItemsCount >= _stpStartInfo.MaxQueueLength + MaxThreads)
 	        {
 	            throw new QueueRejectedException("Queue is at its maximum (" + _stpStartInfo.MaxQueueLength + ")");
 	        }

--- a/SmartThreadPool/SmartThreadPool.csproj
+++ b/SmartThreadPool/SmartThreadPool.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="QueueRejectedException.cs" />
     <Compile Include="WorkItem.WorkItemResult.cs" />
     <Compile Include="CallerThreadContext.cs" />
     <Compile Include="CanceledWorkItemsGroup.cs" />

--- a/SmartThreadPool/SmartThreadPoolMono.csproj
+++ b/SmartThreadPool/SmartThreadPoolMono.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="QueueRejectedException.cs" />
     <Compile Include="WorkItem.WorkItemResult.cs" />
     <Compile Include="CallerThreadContext.cs" />
     <Compile Include="CanceledWorkItemsGroup.cs" />

--- a/SmartThreadPool/SmartThreadPoolSL.csproj
+++ b/SmartThreadPool/SmartThreadPoolSL.csproj
@@ -80,6 +80,7 @@
     <Compile Include="InternalInterfaces.cs" />
     <Compile Include="PriorityQueue.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueueRejectedException.cs" />
     <Compile Include="SLExt.cs" />
     <Compile Include="SmartThreadPool.cs" />
     <Compile Include="SmartThreadPool.ThreadEntry.cs" />


### PR DESCRIPTION
Summary:

- Adds `MaxQueueLength` property that can be `null` or `>= 0` to control queue bounds.
- Exposes read-only `CurrentWorkItemsCount` property from `SmartThreadPool`.

**MaxQueueLength**

Added a configuration property (`MaxQueueLength`) that can be used to enforce an upper-bound on the size of the `_workItemsQueue`.

If the property value is `null` (default), no upper bound is enforced.

If the property value is `0`, items will be rejected instead of queued when the pool is at its maximum thread count and all threads are working on items.

The property may be changed after the pool has `.Start()`ed to adjust the maximum queue length.

Queue limits configured on a pool will be ignored by `WorkItemsGroup`s that use that pool (i.e. limits are only applied to `QueueWorkItem()` calls directly on `SmartThreadPool` instances).

When checking the queue limit and the queue length == the configured limit, items won't be rejected if the pool is going to immediately scale up (i.e. it hasn't reached its max threads). This means the queue limit bends a little bit (and is essentially the configured limit + potential available threads).

If an item is disallowed because the queue is at its maximum, a [`QueueRejectedException`](https://github.com/amibar/SmartThreadPool/pull/8/files#diff-7e870607d2ec8aede09dd238a021a8e5R1359) is thrown.

**CurrentWorkItemsCount**

Exposes the total `CurrentWorkItemsCount`. Involved making the private `_currentWorkItemsCount` `volatile` for better read accuracy.