### PR TITLE
Add ability to wait for Thread to Abort

### DIFF
--- a/SmartThreadPool/Interfaces.cs
+++ b/SmartThreadPool/Interfaces.cs
@@ -118,6 +118,13 @@ namespace Amib.Threading
         void Cancel(bool abortExecution);
 
         /// <summary>
+        /// Cancel all work items using thread abortion
+        /// </summary>
+        /// <param name="abortExecution">True to stop work items by raising ThreadAbortException</param>
+        /// <param name="timeToWaitForThreadAbort">The amount of time to wait for a thread to abort</param>
+        void Cancel(bool abortExecution, TimeSpan timeToWaitForThreadAbort);
+
+        /// <summary>
         /// Wait for all work item to complete.
         /// </summary>
 		void WaitForIdle();
@@ -564,6 +571,21 @@ namespace Amib.Threading
         /// <param name="abortExecution">When true send an AbortException to the executing thread.</param>
         /// <returns>Returns true if the work item was not completed, otherwise false.</returns>
         bool Cancel(bool abortExecution);
+
+        /// <summary>
+        /// Cancel the work item execution.
+        /// If the work item is in the queue then it won't execute
+        /// If the work item is completed, it will remain completed
+        /// If the work item is in progress then the user can check the SmartThreadPool.IsWorkItemCanceled
+        ///   property to check if the work item has been cancelled. If the abortExecution is set to true then
+        ///   the Smart Thread Pool will send an AbortException to the running thread to stop the execution 
+        ///   of the work item. When an in progress work item is canceled its GetResult will throw WorkItemCancelException.
+        /// If the work item is already cancelled it will remain cancelled
+        /// </summary>
+        /// <param name="abortExecution">When true send an AbortException to the executing thread.</param>
+        /// <param name="timeToWaitForThreadAbort">Amount of time to wait for the thread to abort.</param>
+        /// <returns>Returns true if the work item was not completed, otherwise false.</returns>
+        bool Cancel(bool abortExecution, TimeSpan timeToWaitForThreadAbort);
 
 		/// <summary>
 		/// Get the work item's priority

--- a/SmartThreadPool/Interfaces.cs
+++ b/SmartThreadPool/Interfaces.cs
@@ -118,13 +118,6 @@ namespace Amib.Threading
         void Cancel(bool abortExecution);
 
         /// <summary>
-        /// Cancel all work items using thread abortion
-        /// </summary>
-        /// <param name="abortExecution">True to stop work items by raising ThreadAbortException</param>
-        /// <param name="timeToWaitForThreadAbort">The amount of time to wait for a thread to abort</param>
-        void Cancel(bool abortExecution, TimeSpan timeToWaitForThreadAbort);
-
-        /// <summary>
         /// Wait for all work item to complete.
         /// </summary>
 		void WaitForIdle();

--- a/SmartThreadPool/WorkItem.WorkItemResult.cs
+++ b/SmartThreadPool/WorkItem.WorkItemResult.cs
@@ -104,6 +104,11 @@ namespace Amib.Threading.Internal
                 return _workItem.Cancel(abortExecution);
             }
 
+            public bool Cancel(bool abortExecution, TimeSpan timeToWaitForThreadAbort)
+            {
+                return _workItem.Cancel(abortExecution, timeToWaitForThreadAbort);
+            }
+
             public object State
             {
                 get

--- a/SmartThreadPool/WorkItem.cs
+++ b/SmartThreadPool/WorkItem.cs
@@ -709,6 +709,15 @@ namespace Amib.Threading.Internal
         /// <returns>Returns true on success or false if the work item is in progress or already completed</returns>
         private bool Cancel(bool abortExecution)
         {
+            return Cancel(abortExecution, TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// Cancel the work item if it didn't start running yet.
+        /// </summary>
+        /// <returns>Returns true on success or false if the work item is in progress or already completed</returns>
+        private bool Cancel(bool abortExecution, TimeSpan timeToWaitForThreadAbort)
+        {
             bool success = false;
             bool signalComplete = false;
 
@@ -727,6 +736,9 @@ namespace Amib.Threading.Internal
                                 // No need to signalComplete, because we already cancelled this work item
                                 // so it already signaled its completion.
                                 //signalComplete = true;
+                                if (timeToWaitForThreadAbort > TimeSpan.Zero){
+                                    executionThread.Join(timeToWaitForThreadAbort);
+                                }
                             }
                         } 
                         success = true;
@@ -741,6 +753,9 @@ namespace Amib.Threading.Internal
                             if (null != executionThread)
                             {
                                 executionThread.Abort(); // "Cancel"
+                                if (timeToWaitForThreadAbort > TimeSpan.Zero){
+                                    executionThread.Join(timeToWaitForThreadAbort);
+                                }
                                 success = true;
                                 signalComplete = true;
                             }

--- a/SmartThreadPool/WorkItemResultTWrapper.cs
+++ b/SmartThreadPool/WorkItemResultTWrapper.cs
@@ -91,6 +91,11 @@ namespace Amib.Threading.Internal
             return _workItemResult.Cancel(abortExecution);
         }
 
+        public bool Cancel(bool abortExecution, TimeSpan timeToWaitForThreadAbort)
+        {
+            return _workItemResult.Cancel(abortExecution, timeToWaitForThreadAbort);
+        }
+
         public WorkItemPriority WorkItemPriority
         {
             get { return _workItemResult.WorkItemPriority; }


### PR DESCRIPTION
We have the need to wait for a cancelled work item to be aborted, so here's the ability to join to the aborted thread until it exits or there is a timeout